### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm install
+      - run: npm run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: ${{ github.event.repository.name }}
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./out
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Deploy on GitHub Pages
+
+This project can also be hosted on GitHub Pages using the included workflow.
+The workflow builds the site with `next export` and publishes the contents of
+the `out` directory. To enable it:
+
+1. Make sure GitHub Pages is set to deploy from the `gh-pages` branch under the
+   repository settings.
+2. Push changes to the `main` branch or manually run the **Deploy to GitHub
+   Pages** workflow.
+
+The workflow sets `NEXT_PUBLIC_BASE_PATH` to your repository name so that assets
+load correctly when served from `/&lt;repo&gt;`.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,11 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const repo = process.env.NEXT_PUBLIC_BASE_PATH;
+const isProd = process.env.NODE_ENV === 'production';
+
+const nextConfig = {
+  output: 'export',
+  basePath: isProd && repo ? `/${repo}` : undefined,
+  assetPrefix: isProd && repo ? `/${repo}/` : undefined,
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js for static export suitable for GitHub Pages
- add workflow to build and publish to GitHub Pages
- document how to deploy using the workflow

## Testing
- `npm run build` *(fails: `next` not found because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6872b75228608320990d5dafd5613fde